### PR TITLE
環境構築修正(pointsテーブルにカラム追加)

### DIFF
--- a/html/mycakeapp/config/Migrations/20210107061700_CreatePoints.php
+++ b/html/mycakeapp/config/Migrations/20210107061700_CreatePoints.php
@@ -39,6 +39,10 @@ class CreatePoints extends AbstractMigration
             'limit' => 11,
             'null' => false,
         ]);
+        $table->addColumn('is_minus', 'boolean', [
+            'default' => 0,
+            'null' => false,
+        ]);
         $table->addColumn('is_cancelled', 'boolean', [
             'default' => 0,
             'null' => false,

--- a/html/mycakeapp/src/Model/Entity/Point.php
+++ b/html/mycakeapp/src/Model/Entity/Point.php
@@ -36,5 +36,6 @@ class Point extends Entity
         'updated_at' => true,
         'member' => true,
         'schedule' => true,
+        'is_minus' => true,
     ];
 }

--- a/html/mycakeapp/src/Model/Table/PointsTable.php
+++ b/html/mycakeapp/src/Model/Table/PointsTable.php
@@ -68,6 +68,10 @@ class PointsTable extends Table
             ->notEmptyString('point');
 
         $validator
+            ->boolean('is_minus')
+            ->notEmptyString('is_minus');
+
+        $validator
             ->boolean('is_cancelled')
             ->notEmptyString('is_cancelled');
 

--- a/html/mycakeapp/src/Template/Members/view.ctp
+++ b/html/mycakeapp/src/Template/Members/view.ctp
@@ -134,6 +134,7 @@
                 <th scope="col"><?= __('Schedule Id') ?></th>
                 <th scope="col"><?= __('Point') ?></th>
                 <th scope="col"><?= __('Is Cancelled') ?></th>
+                <th scope="col"><?= __('Is Minus') ?></th>
                 <th scope="col"><?= __('Created At') ?></th>
                 <th scope="col"><?= __('Updated At') ?></th>
                 <th scope="col" class="actions"><?= __('Actions') ?></th>

--- a/html/mycakeapp/src/Template/Points/add.ctp
+++ b/html/mycakeapp/src/Template/Points/add.ctp
@@ -21,6 +21,7 @@
         <?php
             echo $this->Form->control('point');
             echo $this->Form->control('is_cancelled');
+            echo $this->Form->control('is_minus');
             echo $this->Form->control('created_at');
             echo $this->Form->control('updated_at');
         ?>

--- a/html/mycakeapp/src/Template/Points/edit.ctp
+++ b/html/mycakeapp/src/Template/Points/edit.ctp
@@ -27,6 +27,7 @@
         <?php
             echo $this->Form->control('point');
             echo $this->Form->control('is_cancelled');
+            echo $this->Form->control('is_minus');
             echo $this->Form->control('created_at');
             echo $this->Form->control('updated_at');
         ?>

--- a/html/mycakeapp/src/Template/Points/index.ctp
+++ b/html/mycakeapp/src/Template/Points/index.ctp
@@ -25,6 +25,7 @@
                 <th scope="col"><?= $this->Paginator->sort('record_number') ?></th>
                 <th scope="col"><?= $this->Paginator->sort('point') ?></th>
                 <th scope="col"><?= $this->Paginator->sort('is_cancelled') ?></th>
+                <th scope="col"><?= $this->Paginator->sort('is_minus') ?></th>
                 <th scope="col"><?= $this->Paginator->sort('created_at') ?></th>
                 <th scope="col"><?= $this->Paginator->sort('updated_at') ?></th>
                 <th scope="col" class="actions"><?= __('Actions') ?></th>

--- a/html/mycakeapp/src/Template/Points/view.ctp
+++ b/html/mycakeapp/src/Template/Points/view.ctp
@@ -53,5 +53,9 @@
             <th scope="row"><?= __('Is Cancelled') ?></th>
             <td><?= $point->is_cancelled ? __('Yes') : __('No'); ?></td>
         </tr>
+        <tr>
+            <th scope="row"><?= __('Is Minus') ?></th>
+            <td><?= $point->is_cancelled ? __('Yes') : __('No'); ?></td>
+        </tr>
     </table>
 </div>

--- a/html/mycakeapp/src/Template/Schedules/view.ctp
+++ b/html/mycakeapp/src/Template/Schedules/view.ctp
@@ -97,6 +97,7 @@
                 <th scope="col"><?= __('Schedule Id') ?></th>
                 <th scope="col"><?= __('Point') ?></th>
                 <th scope="col"><?= __('Is Cancelled') ?></th>
+                <th scope="col"><?= __('Is Minus') ?></th>
                 <th scope="col"><?= __('Created At') ?></th>
                 <th scope="col"><?= __('Updated At') ?></th>
                 <th scope="col" class="actions"><?= __('Actions') ?></th>

--- a/html/mycakeapp/tests/Fixture/PointsFixture.php
+++ b/html/mycakeapp/tests/Fixture/PointsFixture.php
@@ -22,6 +22,7 @@ class PointsFixture extends TestFixture
         'record_number' => ['type' => 'string', 'length' => 2, 'null' => false, 'default' => null, 'collate' => 'utf8_general_ci', 'comment' => '', 'precision' => null, 'fixed' => null],
         'point' => ['type' => 'integer', 'length' => null, 'unsigned' => false, 'null' => false, 'default' => null, 'comment' => '', 'precision' => null, 'autoIncrement' => null],
         'is_cancelled' => ['type' => 'boolean', 'length' => null, 'null' => false, 'default' => '0', 'comment' => '', 'precision' => null],
+        'is_minus' => ['type' => 'boolean', 'length' => null, 'null' => false, 'default' => '0', 'comment' => '', 'precision' => null],
         'created_at' => ['type' => 'datetime', 'length' => null, 'null' => false, 'default' => null, 'comment' => '', 'precision' => null],
         'updated_at' => ['type' => 'datetime', 'length' => null, 'null' => false, 'default' => null, 'comment' => '', 'precision' => null],
         '_constraints' => [
@@ -48,6 +49,7 @@ class PointsFixture extends TestFixture
                 'record_number' => '2a48fe82-7aaa-49ab-b220-da41b9066e64',
                 'point' => 1,
                 'is_cancelled' => 1,
+                'is_minus' => 1,
                 'created_at' => '2021-01-07 16:33:46',
                 'updated_at' => '2021-01-07 16:33:46',
             ],


### PR DESCRIPTION
ポイントの使用と付与どちらもレコードに残す際の一意性を保つため(現状だとどちらか片方しか保存できない