### PR TITLE
環境構築修正(pointテーブルのis_minusを主キーに設定

### DIFF
--- a/html/mycakeapp/config/Migrations/20210107061700_CreatePoints.php
+++ b/html/mycakeapp/config/Migrations/20210107061700_CreatePoints.php
@@ -13,7 +13,7 @@ class CreatePoints extends AbstractMigration
      */
     public function change()
     {
-        $table = $this->table('points', ['id' => false, 'primary_key' => ['member_id', 'schedule_id', 'column_number', 'record_number']]);
+        $table = $this->table('points', ['id' => false, 'primary_key' => ['member_id', 'schedule_id', 'column_number', 'record_number','is_minus']]);
         $table->addColumn('member_id', 'integer', [
             'default' => null,
             'limit' => 11,

--- a/html/mycakeapp/src/Model/Table/PointsTable.php
+++ b/html/mycakeapp/src/Model/Table/PointsTable.php
@@ -36,7 +36,7 @@ class PointsTable extends Table
 
         $this->setTable('points');
         $this->setDisplayField('member_id');
-        $this->setPrimaryKey(['member_id', 'schedule_id', 'column_number', 'record_number']);
+        $this->setPrimaryKey(['member_id', 'schedule_id', 'column_number', 'record_number','is_minus']);
 
         $this->belongsTo('Payments', [
             'foreignKey' => ['member_id', 'schedule_id', 'column_number', 'record_number'],


### PR DESCRIPTION
is_minusをPKとして設定するのを忘れていたため緊急ブランチを作成
(PKにする理由は、決済の使用ポイントと付与ポイントどちらも一意としてレコードに残せるようにするため